### PR TITLE
Proposal: Use standard_product_type for schema.org Product category

### DIFF
--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -496,6 +496,9 @@
       "@type": "Thing",
       "name": {{ product.vendor | json }}
     },
+    {%- if product.standard_product_type -%}
+      "category": {{ product.standard_product_type.type_path | json }},
+    {%- endif -%}
     "offers": [
       {%- for variant in product.variants -%}
         {


### PR DESCRIPTION
**Why are these changes introduced?**

Fixes #0.

**What approach did you take?**

**Other considerations**

**Demo links**

- [Store](url)
- [Editor](url)

**Checklist**
- [ ] Followed [theme code principles](https://github.com/Shopify/dawn/blob/main/.github/CONTRIBUTING.md#theme-code-principles)
- [ ] Linted with [Theme Check](https://github.com/Shopify/theme-check)
- [ ] Tested on [mobile](https://shopify.dev/themes/store/requirements#mobile-browser-requirements)
- [ ] Tested on [multiple browsers](https://shopify.dev/themes/store/requirements#desktop-browser-requirements)
- [ ] Tested for [accessibility](https://shopify.dev/themes/best-practices/accessibility)
